### PR TITLE
fix/change cookie secure and maxAge option

### DIFF
--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ app.use(
     secret: process.env.SESSION_KEY,
     resave: false,
     saveUninitialized: false,
-    cookie: { httpOnly: true, secure: true },
+    cookie: { httpOnly: true, secure: false, maxAge: 24 * 60 * 60 * 1000 }, // 1 day max age
   })
 );
 


### PR DESCRIPTION
changing cookies secure option turns to false again in session in server.js file because it requires in https connection and also set cookie age to 1 day